### PR TITLE
feat: robustness & polish (error boundary, recoverable states, faster entry)

### DIFF
--- a/backend/src/tracker.ts
+++ b/backend/src/tracker.ts
@@ -28,9 +28,17 @@ app.use((error: any, _req: Request, res: Response, _next: NextFunction) => {
     console.error(error);
 
     if (error instanceof z.ZodError) {
-        res.status(422).json({ 
-            message: 'Validation failed.',
-            errors: error.errors 
+        // Surface the first field-level problem so the client can show something
+        // actionable (e.g. "Password: ...") instead of a generic "Validation failed.".
+        const first = error.errors[0];
+        const field = first?.path?.length ? String(first.path[0]) : '';
+        const label = field ? field.charAt(0).toUpperCase() + field.slice(1) : '';
+        const message = first
+            ? (label ? `${label}: ${first.message}` : first.message)
+            : 'Validation failed.';
+        res.status(422).json({
+            message,
+            errors: error.errors,
         });
         return;
     }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Myfin — personal finance dashboard for expense analytics and net worth tracking"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Myfin</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import Navbar from "./pages/navbar";
 import Sidebar from "./pages/sidebar";
 import LoginPage from "./pages/login";
 import { AuthProvider, AuthContext } from "./context/AuthContext";
+import ErrorBoundary from "./components/ErrorBoundary";
+import RouteTitle from "./components/RouteTitle";
 import { YearProvider } from "./context/YearContext"; 
 
 const AppRoutes: React.FC = () => {
@@ -61,13 +63,16 @@ function App() {
 }
 
 const AppWrapper: React.FC = () => (
-    <BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <RouteTitle />
         <AuthProvider>
           <YearProvider>
             <App />
             </YearProvider>
         </AuthProvider>
-    </BrowserRouter>
+      </BrowserRouter>
+    </ErrorBoundary>
 );
 
 export default AppWrapper;

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Box, Typography, Button } from '@mui/material';
+
+type Props = { children: React.ReactNode };
+type State = { hasError: boolean };
+
+// Catches uncaught render errors so a single bad component doesn't blank the
+// whole app to a white screen with no way out.
+class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('Uncaught render error:', error, info);
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: '100vh',
+            gap: 2,
+            p: 3,
+            textAlign: 'center',
+          }}
+        >
+          <Typography variant="h4">Something went wrong</Typography>
+          <Typography variant="body1" sx={{ opacity: 0.7, maxWidth: 420 }}>
+            An unexpected error occurred. Reloading the page usually fixes it.
+          </Typography>
+          <Button variant="contained" onClick={this.handleReload}>
+            Reload
+          </Button>
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/ExpenseFormModal.tsx
+++ b/frontend/src/components/ExpenseFormModal.tsx
@@ -269,6 +269,7 @@ const ExpenseFormModal: React.FC<ExpenseFormModalProps> = ({
             <FormControl fullWidth sx={{ marginBottom: theme.spacing(2) }}>
               <TextField
                 type="number"
+                autoFocus
                 value={amount}
                 onChange={(e) => setAmount(e.target.value)}
                 variant="outlined"
@@ -377,6 +378,9 @@ const ExpenseFormModal: React.FC<ExpenseFormModalProps> = ({
                     )}
               </Select>
             </FormControl>
+
+            {/* Hidden submit so pressing Enter in any field submits the form */}
+            <button type="submit" style={{ display: 'none' }} aria-hidden="true" tabIndex={-1} />
           </Box>
         </DialogContent>
 

--- a/frontend/src/components/RouteTitle.tsx
+++ b/frontend/src/components/RouteTitle.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const PAGE_TITLES: Record<string, string> = {
+  '/': 'Cashflow',
+  '/cashflow': 'Cashflow',
+  '/networth': 'Net Worth',
+  '/login': 'Sign in',
+};
+
+// Keeps the browser tab title in sync with the current route so users can tell
+// pages apart (the CRA default was a static "React App"). Renders nothing.
+const RouteTitle: React.FC = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    const page = PAGE_TITLES[location.pathname];
+    document.title = page ? `${page} · Myfin` : 'Myfin';
+  }, [location.pathname]);
+
+  return null;
+};
+
+export default RouteTitle;

--- a/frontend/src/components/StateMessage.tsx
+++ b/frontend/src/components/StateMessage.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Box, Typography, Button, CircularProgress } from '@mui/material';
+import DashboardBox from './DashboardBox';
+
+type StateMessageProps = {
+  variant: 'loading' | 'error' | 'empty';
+  title?: string;
+  message?: string;
+  onRetry?: () => void;
+};
+
+// A styled, recoverable replacement for the bare <div>Loading…</div> /
+// <div>Error…</div> / <div>No data</div> placeholders the dashboards used to
+// render. Spans the full grid width so it reads as an intentional state.
+const StateMessage: React.FC<StateMessageProps> = ({
+  variant,
+  title,
+  message,
+  onRetry,
+}) => (
+  <DashboardBox
+    sx={{
+      gridColumn: '1 / -1',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      textAlign: 'center',
+      gap: 1.25,
+      p: 3,
+      minHeight: 160,
+    }}
+  >
+    {variant === 'loading' && <CircularProgress size={28} />}
+
+    {title && (
+      <Typography variant="h5" sx={{ fontWeight: 600 }}>
+        {title}
+      </Typography>
+    )}
+
+    {message && (
+      <Typography variant="body2" sx={{ opacity: 0.75, maxWidth: 360 }}>
+        {message}
+      </Typography>
+    )}
+
+    {variant === 'error' && onRetry && (
+      <Box sx={{ mt: 1 }}>
+        <Button variant="outlined" size="small" onClick={onRetry}>
+          Retry
+        </Button>
+      </Box>
+    )}
+  </DashboardBox>
+);
+
+export default StateMessage;

--- a/frontend/src/pages/cashflow/Row1.tsx
+++ b/frontend/src/pages/cashflow/Row1.tsx
@@ -3,6 +3,7 @@ import { Box } from '@mui/material';
 import DashboardBox from '../../components/DashboardBox';
 import BoxHeader from '../../components/BoxHeader';
 import FinancialMetricBox from '../../components/FinancialMetricsBox';
+import StateMessage from '../../components/StateMessage';
 import {
     BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, Label, ResponsiveContainer
 } from 'recharts';
@@ -84,16 +85,18 @@ const Row1: React.FC = () => {
     const [chartExpense, setChartExpense] = useState<TransformedDataItem[]>([]);
     const [isLoading, setLoading] = useState(true);
     const [error, setError] = useState<Error | null>(null);
+    const [retryKey, setRetryKey] = useState(0);
     const authContext = useContext(AuthContext);
     const token = authContext?.token;
-   
+
 
 
     useEffect(() => {
         if (!token || !authContext) return;
-        
+
         const fetchData = async () => {
             setLoading(true);
+            setError(null);
             const headers = {
                 'Content-Type': 'application/json',
                 'Authorization': `Bearer ${authContext.token}`
@@ -129,13 +132,11 @@ const Row1: React.FC = () => {
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
         fetchData();
-    }, [authContext, token, year]);
+    }, [authContext, token, year, retryKey]);
 
-    if (isLoading) return <div>Loading...</div>;
-    if (error) return <div>Error loading data.</div>;
-    if (!financialData.length) return <div>No data available.</div>;
-    if (!chartData.length) return <div>No data available.</div>;
-    if (!chartExpense.length) return <div>No data available.</div>;
+    if (isLoading) return <StateMessage variant="loading" message="Loading your dashboard…" />;
+    if (error) return <StateMessage variant="error" title="Couldn't load data" message="Something went wrong loading your dashboard." onRetry={() => setRetryKey((k) => k + 1)} />;
+    if (!financialData.length || !chartData.length || !chartExpense.length) return <StateMessage variant="empty" title="No data yet" message="Add a transaction with the + button to see your cashflow." />;
     const latestMonth = financialData[financialData.length - 1]?.report_year;
     const latestMonthData = financialData.filter(data => data.report_year === latestMonth);
     const { total_income_value, savings_rate_value,total_yearly_expenses,cumulative_net_income_value } = latestMonthData[0] || {};

--- a/frontend/src/pages/cashflow/Row2.tsx
+++ b/frontend/src/pages/cashflow/Row2.tsx
@@ -2,6 +2,7 @@ import DashboardBox from '../../components/DashboardBox';
 import React, { useMemo, useEffect, useState, useContext } from 'react';
 import { useTheme, Box } from '@mui/material';
 import BoxHeader from '../../components/BoxHeader';
+import StateMessage from '../../components/StateMessage';
 import { DataGrid, GridToolbar } from "@mui/x-data-grid";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, BarChart, Bar, Label } from 'recharts';
 import { AuthContext } from '../../context/AuthContext';
@@ -86,6 +87,7 @@ const Row2: React.FC = () => {
     const [listData, setListData] = useState<TransformedList[]>([]);
     const [isLoading, setLoading] = useState(true);
     const [error, setError] = useState<Error | null>(null);
+    const [retryKey, setRetryKey] = useState(0);
     const [isolatedCategory, setIsolatedCategory] = useState<string | null>(null);
     const authContext = useContext(AuthContext);
     const token = authContext?.token;
@@ -110,6 +112,8 @@ const Row2: React.FC = () => {
         if (!token || !authContext) return;
 
         const fetchData = async () => {
+            setLoading(true);
+            setError(null);
             const headers = {
                 'Content-Type': 'application/json',
                 'Authorization': `Bearer ${authContext.token}`
@@ -145,18 +149,16 @@ const Row2: React.FC = () => {
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
         fetchData();
-    }, [authContext, token, year]);
+    }, [authContext, token, year, retryKey]);
 
     const categoryKeys = useMemo(() => {
         if (chartData.length === 0) return [];
         return Object.keys(chartData[0]).filter(key => key !== 'time');
     }, [chartData]);
 
-    if (isLoading) return <div>Loading...</div>;
-    if (error) return <div>Error loading data.</div>;
-    if (!chartData.length) return <div>No data available.</div>;
-    if (!stuckData.length) return <div>No data available.</div>;
-    if (!listData.length) return <div>No data available.</div>;
+    if (isLoading) return <StateMessage variant="loading" message="Loading transactions…" />;
+    if (error) return <StateMessage variant="error" title="Couldn't load data" message="Something went wrong loading your transactions." onRetry={() => setRetryKey((k) => k + 1)} />;
+    if (!chartData.length || !stuckData.length || !listData.length) return <StateMessage variant="empty" title="No transactions yet" message="Add a transaction with the + button to see your charts and history." />;
 
     const latestStuckDataMonth = stuckData.length > 0 ? stuckData[stuckData.length - 1].month : '';
     const latestChartDataTime = chartData.length > 0 ? chartData[chartData.length - 1].time : '';

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -102,6 +102,8 @@ const LoginPage: React.FC = () => {
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                         required
+                        helperText={!isLogin ? 'At least 6 characters' : undefined}
+                        inputProps={{ minLength: !isLogin ? 6 : undefined }}
                     />
                     {error && (
                         <Typography color="error" variant="body2" align="center" sx={{ mt: 2 }}>

--- a/frontend/src/pages/networth/Row1.tsx
+++ b/frontend/src/pages/networth/Row1.tsx
@@ -3,6 +3,7 @@ import { Box } from '@mui/material';
 import DashboardBox from '../../components/DashboardBox';
 import BoxHeader from '../../components/BoxHeader';
 import FinancialMetricBox from '../../components/FinancialMetricsBox';
+import StateMessage from '../../components/StateMessage';
 import { AuthContext } from '../../context/AuthContext';
 import { apiFetch } from '../../utils/apiFetch';
 import { useYear } from '../../context/YearContext';
@@ -71,11 +72,14 @@ const Row1: React.FC = () => {
   const [allocationAbsolute, setAllocationAbsolute] = useState<AllocationChartItem[]>([]);
   const [isLoading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
 
   useEffect(() => {
     if (!token || !authContext) return;
 
     const fetchSummaryAndAllocation = async () => {
+      setLoading(true);
+      setError(null);
       const headers = {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${authContext.token}`,
@@ -125,11 +129,11 @@ const Row1: React.FC = () => {
     };
 // eslint-disable-next-line react-hooks/exhaustive-deps
     fetchSummaryAndAllocation();
-  }, [authContext, token, year]);
+  }, [authContext, token, year, retryKey]);
 
-  if (isLoading) return <div>Loading net worth...</div>;
-  if (error) return <div>Error loading net worth.</div>;
-  if (!summary) return <div>No net worth data available.</div>;
+  if (isLoading) return <StateMessage variant="loading" message="Loading net worth…" />;
+  if (error) return <StateMessage variant="error" title="Couldn't load net worth" message="Something went wrong loading your net worth." onRetry={() => setRetryKey((k) => k + 1)} />;
+  if (!summary) return <StateMessage variant="empty" title="No net worth data yet" message="Add a net worth value with the + button to get started." />;
 
   const {
     currentNetworth,

--- a/frontend/src/pages/networth/Row2.tsx
+++ b/frontend/src/pages/networth/Row2.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import DashboardBox from '../../components/DashboardBox';
 import BoxHeader from '../../components/BoxHeader';
+import StateMessage from '../../components/StateMessage';
 import { AuthContext } from '../../context/AuthContext';
 import { apiFetch } from '../../utils/apiFetch';
 import { useYear } from '../../context/YearContext';
@@ -107,11 +108,14 @@ const Row2: React.FC = () => {
   const [allocationPercent, setAllocationPercent] = useState<AllocationChartItem[]>([]);
   const [isLoading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
 
   useEffect(() => {
     if (!token || !authContext) return;
 
     const fetchMetrics = async () => {
+      setLoading(true);
+      setError(null);
       const headers = {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${authContext.token}`,
@@ -200,11 +204,11 @@ const Row2: React.FC = () => {
     };
 // eslint-disable-next-line react-hooks/exhaustive-deps
     fetchMetrics();
-  }, [authContext, token, year]);
+  }, [authContext, token, year, retryKey]);
 
-  if (isLoading) return <div>Loading performance...</div>;
-  if (error) return <div>Error loading performance data.</div>;
-  if (!metrics.length) return <div>No performance data available.</div>;
+  if (isLoading) return <StateMessage variant="loading" message="Loading performance…" />;
+  if (error) return <StateMessage variant="error" title="Couldn't load performance" message="Something went wrong loading your net worth performance." onRetry={() => setRetryKey((k) => k + 1)} />;
+  if (!metrics.length) return <StateMessage variant="empty" title="No performance data yet" message="Add net worth values across a few months to see performance." />;
 
   const allocationKeys =
     allocationPercent.length > 0


### PR DESCRIPTION
Third tier of usability improvements, branched off master after #73 and #74 merged. Three small, self-contained commits. **Please review — do not merge yet.**

## What's in here

### 1. Top-level error boundary + per-route page titles (`feat(app)`)
- Wraps the app in an `ErrorBoundary` so an uncaught render error shows a "Something went wrong" screen with a **Reload** button instead of a white screen.
- A `RouteTitle` helper syncs the browser tab title to the current page (`Cashflow · Myfin`, `Net Worth · Myfin`, `Sign in · Myfin`); the static title is now `Myfin` instead of the CRA default `React App`.

### 2. Styled, retryable loading/error/empty states (`feat(dashboard)`)
- Replaces the bare `<div>Loading…</div>` / `<div>Error…</div>` / `<div>No data available.</div>` placeholders in all four dashboard rows with a shared `StateMessage` card.
- Error states now have a **Retry** button (each row gained a `retryKey` that re-runs its fetch and clears the prior error), and empty states explain how to add the first transaction instead of dead-ending.

### 3. Quicker entry & clearer validation (`feat(forms)`)
- Add form: **Amount autofocuses** on open and a hidden submit lets **Enter** submit from any field (open → type → Enter, no mouse).
- Login: the signup password field shows its **"At least 6 characters"** rule up front and enforces a native min length.
- Backend: Zod validation errors return the first **field-level message** (e.g. `Password: …`) instead of a generic "Validation failed.".

## New files
`frontend/src/components/ErrorBoundary.tsx`, `RouteTitle.tsx`, `StateMessage.tsx`

## Verification
- backend `npm run build` (tsc) — clean
- frontend `CI=true npm run build` — `Compiled successfully` (no lint-warning-as-error regressions)
- No DB migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)