### PR TITLE
feat: edit & delete transactions (cashflow + net worth)

### DIFF
--- a/backend/src/modules/cashflow/cashflow.controller.ts
+++ b/backend/src/modules/cashflow/cashflow.controller.ts
@@ -13,6 +13,9 @@ const transactionSchema = z.object({
     categoryId: z.number(),
 });
 
+// Bounded to the int4 range so an out-of-range id is a clean 422, not a DB 500.
+const idParamSchema = z.coerce.number().int().positive().max(2147483647);
+
 
 
 // function to get the expenses
@@ -41,6 +44,54 @@ export const createTransaction = async (req: AuthenticatedRequest, res: Response
             message: 'Transaction created successfully!',
             transaction: result.rows[0],
         });
+    } catch (err) {
+        next(err);
+        return;
+    }
+};
+
+// Function to update an existing transaction (scoped to the owner)
+export const updateTransaction = async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId;
+        if (!userId) {
+            return res.status(401).json({ message: 'Not authenticated.' });
+        }
+
+        const id = idParamSchema.parse(req.params.id);
+        const { date, amount, typeId, categoryId } = transactionSchema.parse(req.body);
+
+        const result = await feedService.updateTransaction(id, date, amount, typeId, categoryId, userId);
+        if (result.rowCount === 0) {
+            return res.status(404).json({ message: 'Transaction not found.' });
+        }
+
+        return res.status(200).json({
+            message: 'Transaction updated successfully!',
+            transaction: result.rows[0],
+        });
+    } catch (err) {
+        next(err);
+        return;
+    }
+};
+
+// Function to delete a transaction (scoped to the owner)
+export const deleteTransaction = async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId;
+        if (!userId) {
+            return res.status(401).json({ message: 'Not authenticated.' });
+        }
+
+        const id = idParamSchema.parse(req.params.id);
+
+        const result = await feedService.deleteTransaction(id, userId);
+        if (result.rowCount === 0) {
+            return res.status(404).json({ message: 'Transaction not found.' });
+        }
+
+        return res.status(200).json({ message: 'Transaction deleted successfully!' });
     } catch (err) {
         next(err);
         return;

--- a/backend/src/modules/cashflow/cashflow.routes.ts
+++ b/backend/src/modules/cashflow/cashflow.routes.ts
@@ -10,6 +10,12 @@ router.get('/expense-categories', feedController.getExpenseCategories);
 // POST /api/cashflow/transaction
 router.post('/transaction', isAuth, feedController.createTransaction);
 
+// PATCH /api/cashflow/transaction/:id
+router.patch('/transaction/:id', isAuth, feedController.updateTransaction);
+
+// DELETE /api/cashflow/transaction/:id
+router.delete('/transaction/:id', isAuth, feedController.deleteTransaction);
+
 // Get /api/cashflow/timeseries
 router.get('/timeseries', isAuth, feedController.getTimeSeries);
 

--- a/backend/src/modules/cashflow/cashflow.service.ts
+++ b/backend/src/modules/cashflow/cashflow.service.ts
@@ -11,6 +11,25 @@ export const createTransaction = (date: string, amount: number, typeId: number, 
     );
 };
 
+// Scoped by user_id so a user can only update their own transactions.
+export const updateTransaction = (id: number, date: string, amount: number, typeId: number, categoryId: number, userId: string) => {
+    return query(
+        `UPDATE transactions
+         SET date = $1, amount = $2, type_id = $3, category_id = $4
+         WHERE id = $5 AND user_id = $6
+         RETURNING *`,
+        [date, amount, typeId, categoryId, id, userId]
+    );
+};
+
+// Scoped by user_id so a user can only delete their own transactions.
+export const deleteTransaction = (id: number, userId: string) => {
+    return query(
+        'DELETE FROM transactions WHERE id = $1 AND user_id = $2 RETURNING id',
+        [id, userId]
+    );
+};
+
 export const getTimeSeries = (userId: string, year:number) => {
     return query(
       `SELECT 
@@ -76,11 +95,14 @@ export const getFinancialDetails = (userId: string, year:number) => {
 
 export const getExpenseTable = (userId: string, year: number) => {
     return query(
-      `SELECT  
+      `SELECT
+        t.id,
         to_char(t.date, 'YYYY-MM-DD') AS date,
         t.amount,
         et.type_name as type,
-        ec.category_name as category
+        t.type_id,
+        ec.category_name as category,
+        t.category_id
       FROM transactions t
       INNER JOIN expense_categories ec ON ec.id = t.category_id 
       INNER JOIN expense_types et on et.id = t.type_id 

--- a/backend/src/modules/networth/networth.controller.ts
+++ b/backend/src/modules/networth/networth.controller.ts
@@ -14,6 +14,9 @@ const transactionSchema = z.object({
     institutionId: z.number(),
 });
 
+// Bounded to the int4 range so an out-of-range id is a clean 4xx, not a DB 500.
+const idParamSchema = z.coerce.number().int().positive().max(2147483647);
+
 
 // function to add networth trasaction
 export const createNetworthTransaction = async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
@@ -39,6 +42,75 @@ export const createNetworthTransaction = async (req: AuthenticatedRequest, res: 
         }
         return next(err);
       }
+};
+
+// function to list a user's networth transactions for a year
+export const getNetworthTable = async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId;
+        if (!userId) {
+            return res.status(401).json({ message: 'Not authenticated.' });
+        }
+        const year =
+            typeof req.query.year === 'string'
+                ? parseInt(req.query.year, 10)
+                : new Date().getFullYear();
+        const result = await networthService.getNetworthTable(userId, year);
+        return res.status(200).json(result.rows);
+    } catch (err) {
+        next(err);
+        return;
+    }
+};
+
+// function to update an existing networth transaction (scoped to the owner)
+export const updateNetworthTransaction = async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId;
+        if (!userId) {
+            return res.status(401).json({ message: 'Not authenticated.' });
+        }
+        const id = idParamSchema.parse(req.params.id);
+        const { date, amount, typeId, categoryId, institutionId } = transactionSchema.parse(req.body);
+
+        const result = await networthService.updateNetworthTransaction(id, date, amount, typeId, categoryId, institutionId, userId);
+        if (result.rowCount === 0) {
+            return res.status(404).json({ message: 'Transaction not found.' });
+        }
+
+        return res.status(200).json({
+            message: 'Transaction updated successfully!',
+            transaction: result.rows[0],
+        });
+    } catch (err) {
+        if (err instanceof ZodError) {
+            return res.status(400).json({ message: 'Invalid request body', errors: err.errors });
+        }
+        return next(err);
+    }
+};
+
+// function to delete a networth transaction (scoped to the owner)
+export const deleteNetworthTransaction = async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId;
+        if (!userId) {
+            return res.status(401).json({ message: 'Not authenticated.' });
+        }
+        const id = idParamSchema.parse(req.params.id);
+
+        const result = await networthService.deleteNetworthTransaction(id, userId);
+        if (result.rowCount === 0) {
+            return res.status(404).json({ message: 'Transaction not found.' });
+        }
+
+        return res.status(200).json({ message: 'Transaction deleted successfully!' });
+    } catch (err) {
+        if (err instanceof ZodError) {
+            return res.status(400).json({ message: 'Invalid request', errors: err.errors });
+        }
+        return next(err);
+    }
 };
 
 // function to get the categories

--- a/backend/src/modules/networth/networth.routes.ts
+++ b/backend/src/modules/networth/networth.routes.ts
@@ -9,6 +9,15 @@ const router = express.Router();
 // POST /api/networth/transactions
 router.post('/transactions', isAuth, networthController.createNetworthTransaction);
 
+// GET /api/networth/list-transactions
+router.get('/list-transactions', isAuth, networthController.getNetworthTable);
+
+// PATCH /api/networth/transactions/:id
+router.patch('/transactions/:id', isAuth, networthController.updateNetworthTransaction);
+
+// DELETE /api/networth/transactions/:id
+router.delete('/transactions/:id', isAuth, networthController.deleteNetworthTransaction);
+
 // GET /api/networth/summary
 router.get('/summary', isAuth, networthController.getNetworthSummary);
 

--- a/backend/src/modules/networth/networth.service.ts
+++ b/backend/src/modules/networth/networth.service.ts
@@ -19,6 +19,52 @@ export const createNetworthTransaction = (date: string, amount: number, typeId: 
     );
 };
 
+// List a user's networth transactions for a year (LEFT JOINs so a row still
+// shows even if a lookup name is missing). type_id/category_id/institution_id
+// are returned so the edit form can prefill the selector.
+export const getNetworthTable = (userId: string, year: number) => {
+    return query(
+      `SELECT
+        t.id,
+        to_char(t.date, 'YYYY-MM-DD') AS date,
+        t.amount,
+        nt.type_name AS type,
+        t.type_id,
+        nc.category_name AS category,
+        t.category_id,
+        ni.institution_name AS institution,
+        t.institution_id
+      FROM networth_transactions t
+      LEFT JOIN networth_types nt ON nt.id = t.type_id
+      LEFT JOIN networth_categories nc ON nc.id = t.category_id
+      LEFT JOIN networth_institutions ni ON ni.id = t.institution_id
+      WHERE t.user_id = $1
+        AND t.date >= make_date($2, 1, 1)
+        AND t.date <  make_date($2 + 1, 1, 1)
+      ORDER BY t.date DESC`,
+      [userId, year]
+    );
+};
+
+// Scoped by user_id so a user can only update their own networth transactions.
+export const updateNetworthTransaction = (id: number, date: string, amount: number, typeId: number, categoryId: number, institutionId: number, userId: string) => {
+    return query(
+        `UPDATE networth_transactions
+         SET date = $1, amount = $2, type_id = $3, category_id = $4, institution_id = $5
+         WHERE id = $6 AND user_id = $7
+         RETURNING *`,
+        [date, amount, typeId, categoryId, institutionId, id, userId]
+    );
+};
+
+// Scoped by user_id so a user can only delete their own networth transactions.
+export const deleteNetworthTransaction = (id: number, userId: string) => {
+    return query(
+        'DELETE FROM networth_transactions WHERE id = $1 AND user_id = $2 RETURNING id',
+        [id, userId]
+    );
+};
+
 
 export const getNetworthCategories = async() => {
     const result = await query(

--- a/frontend/src/components/ExpenseFormModal.tsx
+++ b/frontend/src/components/ExpenseFormModal.tsx
@@ -22,6 +22,7 @@ import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
 import { AuthContext } from '../context/AuthContext';
 import { apiFetch } from '../utils/apiFetch';
+import { useYear } from '../context/YearContext';
 
 interface CashflowCategory {
   type_name: string;
@@ -37,9 +38,20 @@ interface NetworthTypeInstitutionOption {
   institution_name: string;
 }
 
+export interface EditableTransaction {
+  id: number;
+  date: string; // 'YYYY-MM-DD'
+  amount: number;
+  typeId: number;
+  categoryId: number;
+  institutionId?: number; // networth only
+}
+
 interface ExpenseFormModalProps {
   mode?: 'cashflow' | 'networth';
-  onExpenseAdded?: () => void; // Callback to refresh data after adding expense
+  onExpenseAdded?: () => void; // Callback to refresh data after adding/updating
+  editTransaction?: EditableTransaction | null; // when set, open prefilled in edit mode (cashflow)
+  onEditClose?: () => void; // called when an edit dialog closes, so the parent can clear its state
 }
 
 const getTodayStr = () => new Date().toISOString().slice(0, 10);
@@ -47,6 +59,8 @@ const getTodayStr = () => new Date().toISOString().slice(0, 10);
 const ExpenseFormModal: React.FC<ExpenseFormModalProps> = ({
   mode = 'cashflow',
   onExpenseAdded,
+  editTransaction,
+  onEditClose,
 }) => {
   
   const theme = useTheme();
@@ -66,7 +80,12 @@ const ExpenseFormModal: React.FC<ExpenseFormModalProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const [successOpen, setSuccessOpen] = useState(false);
+  const [successMsg, setSuccessMsg] = useState('');
+  const [editingId, setEditingId] = useState<number | null>(null);
   const authContext = useContext(AuthContext);
+  const { year, setYear } = useYear();
+
+  const isEditing = editingId !== null;
 
   // Decide endpoints based on mode
   const categoriesEndpoint =
@@ -79,8 +98,16 @@ const ExpenseFormModal: React.FC<ExpenseFormModalProps> = ({
       ? `/api/cashflow/transaction`
       : `/api/networth/transactions`;
 
-  const title = mode === 'cashflow' ? 'Add Expense' : 'Add Net Worth Value';
-  const submitLabel = mode === 'cashflow' ? 'Add Expense' : 'Add Net Worth';
+  const title = isEditing
+    ? 'Edit Transaction'
+    : mode === 'cashflow'
+      ? 'Add Expense'
+      : 'Add Net Worth Value';
+  const submitLabel = isEditing
+    ? 'Save Changes'
+    : mode === 'cashflow'
+      ? 'Add Expense'
+      : 'Add Net Worth';
 
   // Fetch categories (for cashflow) or type+institution options (for networth)
   useEffect(() => {
@@ -108,6 +135,19 @@ const ExpenseFormModal: React.FC<ExpenseFormModalProps> = ({
     fetchCategories();
   }, [categoriesEndpoint, authContext]);
 
+  // Open prefilled when the parent requests an edit (cashflow only).
+  useEffect(() => {
+    if (!editTransaction) return;
+    setAmount(String(editTransaction.amount));
+    setSelectedDate(editTransaction.date);
+    setSelectedTypeId(editTransaction.typeId);
+    setSelectedCategoryId(editTransaction.categoryId);
+    setSelectedInstitutionId(editTransaction.institutionId ?? null);
+    setEditingId(editTransaction.id);
+    setFormError(null);
+    setOpen(true);
+  }, [editTransaction]);
+
   const handleOpen = () => setOpen(true);
 
   const handleClose = () => {
@@ -118,6 +158,10 @@ const ExpenseFormModal: React.FC<ExpenseFormModalProps> = ({
     setSelectedCategoryId(null);
     setSelectedInstitutionId(null);
     setFormError(null);
+    if (editingId !== null) {
+      setEditingId(null);
+      onEditClose?.();
+    }
   };
 
   // When user picks an option:
@@ -181,9 +225,13 @@ const ExpenseFormModal: React.FC<ExpenseFormModalProps> = ({
 
     try {
       const response = await apiFetch(
-        transactionEndpoint,
+        isEditing
+          ? mode === 'cashflow'
+            ? `/api/cashflow/transaction/${editingId}`
+            : `/api/networth/transactions/${editingId}`
+          : transactionEndpoint,
         {
-          method: 'POST',
+          method: isEditing ? 'PATCH' : 'POST',
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${authContext?.token}`,
@@ -204,7 +252,22 @@ const ExpenseFormModal: React.FC<ExpenseFormModalProps> = ({
         return;
       }
 
+      setSuccessMsg(
+        isEditing
+          ? 'Transaction updated'
+          : mode === 'cashflow'
+            ? 'Transaction added'
+            : 'Net worth value added'
+      );
       setSuccessOpen(true);
+
+      // If the saved date falls in a different year than the one being viewed,
+      // switch to it so the new/edited row stays visible instead of vanishing
+      // from the year-scoped dashboard.
+      const savedYear = Number(selectedDate.slice(0, 4));
+      if (savedYear && savedYear !== year) {
+        setYear(savedYear);
+      }
 
       if (onExpenseAdded) {
         onExpenseAdded();
@@ -418,7 +481,7 @@ const ExpenseFormModal: React.FC<ExpenseFormModalProps> = ({
           variant="filled"
           sx={{ width: '100%' }}
         >
-          {mode === 'cashflow' ? 'Transaction added' : 'Net worth value added'}
+          {successMsg}
         </Alert>
       </Snackbar>
     </>

--- a/frontend/src/pages/cashflow/Row2.tsx
+++ b/frontend/src/pages/cashflow/Row2.tsx
@@ -1,14 +1,28 @@
 import DashboardBox from '../../components/DashboardBox';
 import React, { useMemo, useEffect, useState, useContext } from 'react';
-import { useTheme, Box } from '@mui/material';
+import {
+    useTheme,
+    Box,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    Typography,
+    Snackbar,
+    Alert,
+} from '@mui/material';
 import BoxHeader from '../../components/BoxHeader';
 import StateMessage from '../../components/StateMessage';
-import { DataGrid, GridToolbar } from "@mui/x-data-grid";
+import { DataGrid, GridToolbar, GridActionsCellItem, GridColDef } from "@mui/x-data-grid";
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, BarChart, Bar, Label } from 'recharts';
 import { AuthContext } from '../../context/AuthContext';
 import { apiFetch } from '../../utils/apiFetch';
 import { useYear } from '../../context/YearContext';
 import { formatCurrency, formatCompactCurrency, formatMonthTick } from '../../utils/format';
+import type { EditableTransaction } from '../../components/ExpenseFormModal';
 
 
 
@@ -36,10 +50,18 @@ interface TransformedDataItem {
 
 
 interface TransformedList {
+    id: number;
     date: string;
     type: string;
+    type_id: number;
     category: string;
-    amount: number
+    category_id: number;
+    amount: number;
+}
+
+interface Row2Props {
+    onEditTransaction?: (tx: EditableTransaction) => void;
+    onChanged?: () => void; // refresh after a delete
 }
 
 
@@ -79,28 +101,90 @@ const generateColor = (index: number) => {
     return `hsl(${index * 137.508}, 50%, 60%)`; 
 };
 
-const Row2: React.FC = () => {
+const Row2: React.FC<Row2Props> = ({ onEditTransaction, onChanged }) => {
     const { palette } = useTheme();
     const [chartData, setChartData] = useState<ChartData[]>([]);
-    const { year } = useYear(); 
+    const { year } = useYear();
     const [stuckData, setStuckData] = useState<TransformedDataItem[]>([]);
     const [listData, setListData] = useState<TransformedList[]>([]);
     const [isLoading, setLoading] = useState(true);
     const [error, setError] = useState<Error | null>(null);
     const [retryKey, setRetryKey] = useState(0);
     const [isolatedCategory, setIsolatedCategory] = useState<string | null>(null);
+    const [pendingDelete, setPendingDelete] = useState<TransformedList | null>(null);
+    const [deleting, setDeleting] = useState(false);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
     const authContext = useContext(AuthContext);
     const token = authContext?.token;
 
+    const handleEdit = (row: TransformedList) => {
+        onEditTransaction?.({
+            id: row.id,
+            date: row.date,
+            amount: Number(row.amount),
+            typeId: row.type_id,
+            categoryId: row.category_id,
+        });
+    };
 
-    const columns = [
-        { field: 'id', headerName: 'ID', width: 50 },
+    const confirmDelete = async () => {
+        if (!pendingDelete || !authContext) return;
+        setDeleting(true);
+        try {
+            const response = await apiFetch(
+                `/api/cashflow/transaction/${pendingDelete.id}`,
+                {
+                    method: 'DELETE',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${authContext.token}`,
+                    },
+                },
+                authContext
+            );
+            if (!response.ok) {
+                if (response.status === 404) {
+                    // Already gone (e.g. deleted in another tab) — drop it from the grid.
+                    setPendingDelete(null);
+                    onChanged?.();
+                    return;
+                }
+                const data = await response.json().catch(() => ({}));
+                throw new Error(data?.message || 'Could not delete the transaction.');
+            }
+            setPendingDelete(null);
+            onChanged?.();
+        } catch (err) {
+            setDeleteError(err instanceof Error ? err.message : 'Could not delete the transaction.');
+            setPendingDelete(null);
+        } finally {
+            setDeleting(false);
+        }
+    };
+
+    const columns: GridColDef[] = [
         { field: 'date', headerName: 'Date', width: 100 },
         { field: 'amount', headerName: 'Amount', type: 'number', width: 110, valueFormatter: (params: any) => formatCurrency(Number(params.value)) },
         { field: 'type', headerName: 'Type', width: 100 },
-        { field: 'category', headerName: 'Category', width: 150 },
-      
-        
+        { field: 'category', headerName: 'Category', width: 140 },
+        {
+            field: 'actions',
+            type: 'actions',
+            headerName: '',
+            width: 90,
+            getActions: (params: any) => [
+                <GridActionsCellItem
+                    icon={<EditIcon fontSize="small" />}
+                    label="Edit"
+                    onClick={() => handleEdit(params.row as TransformedList)}
+                />,
+                <GridActionsCellItem
+                    icon={<DeleteIcon fontSize="small" />}
+                    label="Delete"
+                    onClick={() => setPendingDelete(params.row as TransformedList)}
+                />,
+            ],
+        },
     ];
 
     const handleLegendClick = (o: any) => {
@@ -134,11 +218,8 @@ const Row2: React.FC = () => {
 
                 const tableResponse = await apiFetch(`/api/cashflow/list-expenses?year=${year}`, { headers }, authContext);
                 const listExpenses: TransformedList[] = await tableResponse.json();
-                const formattedData = listExpenses.map((item, index) => ({
-                ...item,
-                id: index, // Adding an ID for each item
-                }));
-                setListData(formattedData);
+                // Each row already carries its real DB id (used by the grid and for edit/delete).
+                setListData(listExpenses);
 
                 setLoading(false);
             } catch (error) {
@@ -158,7 +239,7 @@ const Row2: React.FC = () => {
 
     if (isLoading) return <StateMessage variant="loading" message="Loading transactions…" />;
     if (error) return <StateMessage variant="error" title="Couldn't load data" message="Something went wrong loading your transactions." onRetry={() => setRetryKey((k) => k + 1)} />;
-    if (!chartData.length || !stuckData.length || !listData.length) return <StateMessage variant="empty" title="No transactions yet" message="Add a transaction with the + button to see your charts and history." />;
+    if (!listData.length) return <StateMessage variant="empty" title="No transactions yet" message="Add a transaction with the + button to see your charts and history." />;
 
     const latestStuckDataMonth = stuckData.length > 0 ? stuckData[stuckData.length - 1].month : '';
     const latestChartDataTime = chartData.length > 0 ? chartData[chartData.length - 1].time : '';
@@ -273,6 +354,48 @@ const Row2: React.FC = () => {
                     />
                 </Box>
             </DashboardBox>
+
+            {/* Delete confirmation */}
+            <Dialog
+                open={pendingDelete !== null}
+                onClose={() => !deleting && setPendingDelete(null)}
+            >
+                <DialogTitle>Delete transaction?</DialogTitle>
+                <DialogContent>
+                    <Typography variant="body2">
+                        {pendingDelete
+                            ? `Delete the ${pendingDelete.category} transaction of ${formatCurrency(
+                                  Number(pendingDelete.amount)
+                              )} on ${pendingDelete.date}? This can't be undone.`
+                            : ''}
+                    </Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setPendingDelete(null)} color="inherit" disabled={deleting}>
+                        Cancel
+                    </Button>
+                    <Button onClick={confirmDelete} color="error" variant="contained" disabled={deleting}>
+                        {deleting ? 'Deleting…' : 'Delete'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            {/* Delete error feedback */}
+            <Snackbar
+                open={!!deleteError}
+                autoHideDuration={4000}
+                onClose={() => setDeleteError(null)}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+            >
+                <Alert
+                    severity="error"
+                    variant="filled"
+                    onClose={() => setDeleteError(null)}
+                    sx={{ width: '100%' }}
+                >
+                    {deleteError}
+                </Alert>
+            </Snackbar>
     </>
     );
 };

--- a/frontend/src/pages/cashflow/index.tsx
+++ b/frontend/src/pages/cashflow/index.tsx
@@ -1,7 +1,7 @@
 import { Box, useMediaQuery } from "@mui/material";
 import Row1 from "./Row1";
 import Row2 from "./Row2";
-import ExpenseFormModal from "../../components/ExpenseFormModal";
+import ExpenseFormModal, { EditableTransaction } from "../../components/ExpenseFormModal";
 import { useState } from "react";
 
 const gridTemplateLargeScreens = `
@@ -39,6 +39,7 @@ const gridTemplateSmallScreens = `
 const CashFlow = () => {
     const isAboveMediumScreens = useMediaQuery("(min-width: 1200px)");
     const [refreshKey, setRefreshKey] = useState(0);
+    const [editTransaction, setEditTransaction] = useState<EditableTransaction | null>(null);
 
     const handleExpenseAdded = () => {
         // Trigger a refresh of the data by updating the key
@@ -66,8 +67,17 @@ const CashFlow = () => {
             }
         >
             <Row1 key={`row1-${refreshKey}`} />
-            <Row2 key={`row2-${refreshKey}`} />
-            <ExpenseFormModal mode="cashflow" onExpenseAdded={handleExpenseAdded} />
+            <Row2
+                key={`row2-${refreshKey}`}
+                onEditTransaction={setEditTransaction}
+                onChanged={handleExpenseAdded}
+            />
+            <ExpenseFormModal
+                mode="cashflow"
+                onExpenseAdded={handleExpenseAdded}
+                editTransaction={editTransaction}
+                onEditClose={() => setEditTransaction(null)}
+            />
         </Box>
     );
 };

--- a/frontend/src/pages/networth/Transactions.tsx
+++ b/frontend/src/pages/networth/Transactions.tsx
@@ -1,0 +1,260 @@
+import React, { useContext, useEffect, useState } from 'react';
+import {
+  useTheme,
+  Box,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Snackbar,
+  Alert,
+} from '@mui/material';
+import DashboardBox from '../../components/DashboardBox';
+import BoxHeader from '../../components/BoxHeader';
+import StateMessage from '../../components/StateMessage';
+import { DataGrid, GridToolbar, GridActionsCellItem, GridColDef } from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { AuthContext } from '../../context/AuthContext';
+import { apiFetch } from '../../utils/apiFetch';
+import { useYear } from '../../context/YearContext';
+import { formatCurrency } from '../../utils/format';
+import type { EditableTransaction } from '../../components/ExpenseFormModal';
+
+interface NetworthRow {
+  id: number;
+  date: string;
+  type: string;
+  type_id: number;
+  category: string;
+  category_id: number;
+  institution: string;
+  institution_id: number;
+  amount: number;
+}
+
+interface NetworthTransactionsProps {
+  onEditTransaction?: (tx: EditableTransaction) => void;
+  onChanged?: () => void; // refresh after a delete
+}
+
+const NetworthTransactions: React.FC<NetworthTransactionsProps> = ({
+  onEditTransaction,
+  onChanged,
+}) => {
+  const { palette } = useTheme();
+  const { year } = useYear();
+  const authContext = useContext(AuthContext);
+  const token = authContext?.token;
+
+  const [rows, setRows] = useState<NetworthRow[]>([]);
+  const [isLoading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
+  const [pendingDelete, setPendingDelete] = useState<NetworthRow | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token || !authContext) return;
+
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      const headers = {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authContext.token}`,
+      };
+      try {
+        const response = await apiFetch(
+          `/api/networth/list-transactions?year=${year}`,
+          { headers },
+          authContext
+        );
+        const data: NetworthRow[] = await response.json();
+        setRows(Array.isArray(data) ? data : []);
+        setLoading(false);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Unknown error'));
+        setLoading(false);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    fetchData();
+  }, [authContext, token, year, retryKey]);
+
+  const handleEdit = (row: NetworthRow) => {
+    onEditTransaction?.({
+      id: row.id,
+      date: row.date,
+      amount: Number(row.amount),
+      typeId: row.type_id,
+      categoryId: row.category_id,
+      institutionId: row.institution_id,
+    });
+  };
+
+  const confirmDelete = async () => {
+    if (!pendingDelete || !authContext) return;
+    setDeleting(true);
+    try {
+      const response = await apiFetch(
+        `/api/networth/transactions/${pendingDelete.id}`,
+        {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${authContext.token}`,
+          },
+        },
+        authContext
+      );
+      if (!response.ok) {
+        if (response.status === 404) {
+          // Already gone (e.g. deleted in another tab) — drop it from the grid.
+          setPendingDelete(null);
+          onChanged?.();
+          return;
+        }
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data?.message || 'Could not delete the value.');
+      }
+      setPendingDelete(null);
+      onChanged?.();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Could not delete the value.');
+      setPendingDelete(null);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const columns: GridColDef[] = [
+    { field: 'date', headerName: 'Date', width: 100 },
+    {
+      field: 'amount',
+      headerName: 'Amount',
+      type: 'number',
+      width: 120,
+      valueFormatter: (params: any) => formatCurrency(Number(params.value)),
+    },
+    { field: 'type', headerName: 'Type', width: 120 },
+    { field: 'institution', headerName: 'Institution', width: 140 },
+    { field: 'category', headerName: 'Category', width: 120 },
+    {
+      field: 'actions',
+      type: 'actions',
+      headerName: '',
+      width: 90,
+      getActions: (params: any) => [
+        <GridActionsCellItem
+          icon={<EditIcon fontSize="small" />}
+          label="Edit"
+          onClick={() => handleEdit(params.row as NetworthRow)}
+        />,
+        <GridActionsCellItem
+          icon={<DeleteIcon fontSize="small" />}
+          label="Delete"
+          onClick={() => setPendingDelete(params.row as NetworthRow)}
+        />,
+      ],
+    },
+  ];
+
+  if (isLoading) return <StateMessage variant="loading" message="Loading net worth values…" />;
+  if (error)
+    return (
+      <StateMessage
+        variant="error"
+        title="Couldn't load values"
+        message="Something went wrong loading your net worth values."
+        onRetry={() => setRetryKey((k) => k + 1)}
+      />
+    );
+  if (!rows.length)
+    return (
+      <StateMessage
+        variant="empty"
+        title="No net worth values yet"
+        message="Add a net worth value with the + button to see your history."
+      />
+    );
+
+  return (
+    <>
+      <DashboardBox width="100%" sx={{ p: '1rem' }}>
+        <BoxHeader title="Net Worth Values" sideText={`${rows.length} entries`} />
+        <Box
+          mt="1rem"
+          height={320}
+          sx={{
+            '& .MuiDataGrid-root': { color: palette.grey[300], border: 'none' },
+            '& .MuiDataGrid-cell': {
+              borderBottom: `1px solid ${palette.grey[800]} !important`,
+            },
+            '& .MuiDataGrid-columnHeaders': {
+              borderBottom: `1px solid ${palette.grey[800]} !important`,
+            },
+            '& .MuiDataGrid-columnSeparator': { visibility: 'hidden' },
+          }}
+        >
+          <DataGrid
+            columnHeaderHeight={30}
+            rowHeight={35}
+            rows={rows}
+            columns={columns}
+            slots={{ toolbar: GridToolbar }}
+            slotProps={{
+              toolbar: { showQuickFilter: true, csvOptions: { fileName: 'networth-values' } },
+            }}
+            pageSizeOptions={[10, 25, 50]}
+            initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+          />
+        </Box>
+      </DashboardBox>
+
+      {/* Delete confirmation */}
+      <Dialog open={pendingDelete !== null} onClose={() => !deleting && setPendingDelete(null)}>
+        <DialogTitle>Delete net worth value?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            {pendingDelete
+              ? `Delete the ${pendingDelete.institution} value of ${formatCurrency(
+                  Number(pendingDelete.amount)
+                )} on ${pendingDelete.date}? This can't be undone.`
+              : ''}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPendingDelete(null)} color="inherit" disabled={deleting}>
+            Cancel
+          </Button>
+          <Button onClick={confirmDelete} color="error" variant="contained" disabled={deleting}>
+            {deleting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete error feedback */}
+      <Snackbar
+        open={!!deleteError}
+        autoHideDuration={4000}
+        onClose={() => setDeleteError(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity="error"
+          variant="filled"
+          onClose={() => setDeleteError(null)}
+          sx={{ width: '100%' }}
+        >
+          {deleteError}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+export default NetworthTransactions;

--- a/frontend/src/pages/networth/index.tsx
+++ b/frontend/src/pages/networth/index.tsx
@@ -2,7 +2,8 @@ import { Box, useMediaQuery } from "@mui/material";
 import Row1 from "./Row1";
 import Row2 from "./Row2";
 //import YearSelector from "../../components/YearSelector";
-import ExpenseFormModal from "../../components/ExpenseFormModal";
+import ExpenseFormModal, { EditableTransaction } from "../../components/ExpenseFormModal";
+import NetworthTransactions from "./Transactions";
 import { useState } from "react";
 
 const gridTemplateLargeScreens = `
@@ -20,6 +21,7 @@ const gridTemplateLargeScreens = `
 const NetWorth = () => {
     const isAboveMediumScreens = useMediaQuery("(min-width: 1200px)");
     const [refreshKey, setRefreshKey] = useState(0);
+    const [editTransaction, setEditTransaction] = useState<EditableTransaction | null>(null);
 
     const handleExpenseAdded = () => {
         // Trigger a refresh of the data by updating the key
@@ -56,8 +58,20 @@ const NetWorth = () => {
             >
             <Row1 key={`row1-${refreshKey}`} />
             <Row2 key={`row2-${refreshKey}`} />
-            <ExpenseFormModal mode="networth" onExpenseAdded={handleExpenseAdded} />
         </Box>
+
+        <NetworthTransactions
+            key={`tx-${refreshKey}`}
+            onEditTransaction={setEditTransaction}
+            onChanged={handleExpenseAdded}
+        />
+
+        <ExpenseFormModal
+            mode="networth"
+            onExpenseAdded={handleExpenseAdded}
+            editTransaction={editTransaction}
+            onEditClose={() => setEditTransaction(null)}
+        />
     </Box>
     );
 };


### PR DESCRIPTION
Lets users **correct or remove** a transaction instead of a wrong amount/category living forever and silently skewing every chart. Covers both cashflow and net worth, and folds in fixes from an adversarial self-review. Four self-contained commits.

## Cashflow
- **Backend** — `PATCH` / `DELETE /api/cashflow/transaction/:id`, both scoped `WHERE id = $1 AND user_id = $2` (no IDOR; 404 on miss). `:id` validated as a positive, int4-bounded integer. `list-expenses` now returns `id`, `type_id`, `category_id`.
- **Frontend** — per-row **Edit** (reopens the add form pre-filled, saves via PATCH) and **Delete** (confirm dialog). Grid keys off the real DB id.

## Net worth (new table)
The net worth page had only charts and no way to see/fix individual entries.
- **Backend** — `GET /api/networth/list-transactions` (LEFT-joined; returns ids for prefill) + `PATCH` / `DELETE /api/networth/transactions/:id`, same scoping/validation.
- **Frontend** — a new **Net Worth Values** table (date, amount, type, institution, category) with search + CSV export and per-row Edit/Delete, reusing the shared form (now carrying `institutionId`).

## Review fixes folded in
An adversarial review of the cashflow diff surfaced 4 real issues, all fixed here (and built into the net worth code from the start):
1. **(med)** Editing a date into another year made the row vanish from the year-scoped grid → now switches the active year so it stays visible.
2. **(low)** Out-of-range `:id` overflowed Postgres int4 → 500 leaking the driver error → now a clean 4xx via `.max(2147483647)`.
3. **(low)** Empty-state `||` guard hid the whole grid (incl. actions) when a chart series was empty → now keys off the transaction list only.
4. **(low)** Deleting an already-deleted row (404) left the stale row → now drops it and refreshes.

## Verification
- backend `npm run build` (tsc) — clean
- frontend `CI=true npm run build` — `Compiled successfully`
- No DB migration required (reuses existing columns; `transactions`/`networth_transactions` already have `user_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)